### PR TITLE
fix(pandatv): update live link regex pattern

### DIFF
--- a/src/lib/data/platform/pandatv/constants.ts
+++ b/src/lib/data/platform/pandatv/constants.ts
@@ -1,1 +1,1 @@
-export const pandatvRegex = "(?:https?://)?(?:www\\.)?pandalive\\.co\\.kr/live/play/([a-zA-Z0-9]+)"
+export const pandatvRegex = "(?:https?://)?(?:www\\.)?pandalive\\.co\\.kr/(?:live/)?play/([a-zA-Z0-9]+)"


### PR DESCRIPTION
The endPoint pandatv URL is https://www.pandalive.co.kr/play/{room}  but the front is  https://www.pandalive.co.kr/live/play/{room} 